### PR TITLE
chore(examples): default to prod environment

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,8 @@
-VANA_PRIVATE_KEY=0x...              # Builder key, must be registered on-chain
-APP_URL=http://localhost:3001       # Public URL of your deployed app
-VANA_SCOPES=chatgpt.conversations   # Comma-separated scopes
+# You will need register this with Vana Data Gateway here to get started -
+# https://account.vana.org/admin
+# Builder key, must be registered on-chain
+VANA_PRIVATE_KEY=0x...
+# Public URL of your deployed app
+APP_URL=http://localhost:3001
+# Comma-separated scopes
+VANA_SCOPES=chatgpt.conversations

--- a/src/components/ConnectFlow.tsx
+++ b/src/components/ConnectFlow.tsx
@@ -39,7 +39,7 @@ export default function ConnectFlow() {
     initConnect,
     fetchData,
     isLoading,
-  } = useVanaData({ environment: "dev" });
+  } = useVanaData({ environment: "prod" });
 
   const initRef = useRef(false);
   useEffect(() => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,5 +8,5 @@ export const config = createVanaConfig({
     process.env.VANA_APP_PRIVATE_KEY) as `0x${string}`,
   scopes: SCOPES,
   appUrl: process.env.APP_URL ?? "",
-  environment: "dev",
+  environment: "prod",
 });


### PR DESCRIPTION
## Summary
- Switch default environment from `dev` to `prod` in both server config and client hook
- Add helpful comment in `.env.local.example` about registering with the Data Gateway

New builders register on the production Data Gateway, so the starter should point there out of the box to avoid "builder not registered" errors on first run.

## Test plan
- [x] Clone fresh, set `VANA_PRIVATE_KEY` for a prod-registered builder
- [x] Run `pnpm dev` — confirm no "builder not registered" error
- [ ] Verify connect flow works end-to-end against prod gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)