### PR TITLE
Add Claude Code skill for scaffolding data apps

### DIFF
--- a/.claude/skills/vana-data-app/SKILL.md
+++ b/.claude/skills/vana-data-app/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: vana-data-app
+description: >
+  Create and customize Vana data apps that access users' portable personal data via
+  the Vana Connect SDK. Use when asked to "create a data app", "new vana app",
+  "build an app with user data", "customize the starter", "add a scope",
+  "change data source", or when working with @opendatalabs/connect or the
+  vana-connect-starter repo.
+---
+
+# Vana Data App Builder
+
+Build Next.js applications that access users' portable personal data (ChatGPT conversations,
+Instagram posts, Spotify history, etc.) via the Vana Connect protocol. Apps use the
+`@opendatalabs/connect` SDK for session creation, grant polling, and data retrieval.
+
+## Core Architecture
+
+The data flow has three steps, all handled by the SDK:
+
+1. **Create session** (server) — `connect(config)` returns a `connectUrl` deep link + `sessionId`
+2. **Poll for approval** (client) — `useVanaData()` hook polls until the user approves in DataConnect
+3. **Fetch data** (server) — `getData({ privateKey, grant, environment })` retrieves user data
+
+The grant flow: Builder backend creates session via Session Relay, user approves in DataConnect
+desktop app, DataConnect registers an on-chain grant (EIP-712 signed), builder fetches data from
+the user's Personal Server using the grant.
+
+## File Roles — What to Change vs. Leave Alone
+
+### CUSTOMIZE these files:
+
+| File | What to change |
+|------|---------------|
+| `src/config.ts` | `SCOPES` array — pick data types for your use case |
+| `src/app/manifest.json/route.ts` | App name, short_name, privacy/terms/support URLs |
+| `src/components/ConnectFlow.tsx` | UI — redesign data display, add visualizations, features |
+| `src/app/page.tsx` | Homepage — title, description, branding, layout |
+| `src/app/globals.css` | Styling — colors, typography, components |
+| `src/app/layout.tsx` | Metadata — page title, description |
+| `src/app/icon.svg` | App icon (DataConnect resolves `/icon.svg` → `/icon.png` → `/favicon.ico`) |
+
+### DO NOT modify these files:
+
+| File | Why |
+|------|-----|
+| `src/app/api/connect/route.ts` | Thin SDK wrapper — works as-is |
+| `src/app/api/data/route.ts` | Thin SDK wrapper — works as-is |
+| `src/app/api/webhook/route.ts` | Stub — extend for production but don't break the interface |
+
+## Workflow
+
+### Step 1 — Define the app concept
+
+Ask the user (if not clear):
+1. What does the app do with the data? (analyze, visualize, export, transform)
+2. Which data sources? (chatgpt, instagram, spotify, gmail, etc.)
+3. What scopes are needed? (e.g. `chatgpt.conversations`, `instagram.posts`)
+
+Available scope schemas: https://github.com/vana-com/data-connectors/tree/main/schemas
+
+### Step 2 — Scaffold or clone the starter
+
+If starting fresh:
+```bash
+git clone https://github.com/vana-com/vana-connect-starter.git my-data-app
+cd my-data-app
+pnpm install
+cp .env.local.example .env.local
+```
+
+Required environment variables:
+- `VANA_PRIVATE_KEY` — Builder private key (register at https://account.vana.org/admin)
+- `APP_URL` — `http://localhost:3001` for dev, HTTPS domain for production
+
+### Step 3 — Configure scopes
+
+Edit `src/config.ts`:
+
+```typescript
+import { createVanaConfig } from "@opendatalabs/connect/server";
+
+const SCOPES = ["chatgpt.conversations"]; // Change to your data types
+
+export const config = createVanaConfig({
+  privateKey: (process.env.VANA_PRIVATE_KEY ??
+    process.env.VANA_APP_PRIVATE_KEY) as `0x${string}`,
+  scopes: SCOPES,
+  appUrl: process.env.APP_URL ?? "",
+});
+```
+
+Multiple scopes are supported: `["chatgpt.conversations", "instagram.posts"]`
+
+### Step 4 — Update app identity
+
+Edit `src/app/manifest.json/route.ts` — change the manifest object:
+
+```typescript
+const manifest = {
+  name: "Your App Name",
+  short_name: "YourApp",
+  start_url: "/",
+  display: "standalone",
+  background_color: "#09090b",
+  theme_color: "#09090b",
+  icons: [{ src: "/icon.svg", sizes: "any", type: "image/svg+xml" }],
+  vana: vanaBlock,
+};
+```
+
+Update the URLs passed to `signVanaManifest()`:
+- `privacyPolicyUrl`
+- `termsUrl`
+- `supportUrl`
+- `webhookUrl`
+
+### Step 5 — Build the UI
+
+The `ConnectFlow` component uses `useVanaData()` from `@opendatalabs/connect/react`:
+
+```typescript
+const {
+  status,      // "idle" | "connecting" | "waiting" | "approved" | "denied" | "expired" | "error"
+  grant,       // { grantId, userAddress, builderAddress, scopes, serverAddress? }
+  data,        // Fetched user data (Record<string, unknown>)
+  error,       // Error message string
+  connectUrl,  // Deep link URL to DataConnect
+  initConnect, // Start session
+  fetchData,   // Retrieve data using grant
+  isLoading,   // Loading state boolean
+} = useVanaData();
+```
+
+Status flow: `idle` → `connecting` → `waiting` → `approved` → (fetch data)
+
+The component must:
+1. Call `initConnect()` once on mount (use `useRef` guard in StrictMode)
+2. Show "Connect with Vana" link to `connectUrl` when status is `waiting`
+3. Call `fetchData()` after approval to get user data
+4. Display the data in your app-specific way
+
+Data comes back keyed by scope: `{ "chatgpt.conversations": [...] }`
+
+### Step 6 — Test locally
+
+```bash
+pnpm dev  # Opens on http://localhost:3001
+```
+
+E2E flow:
+1. Open http://localhost:3001
+2. Click "Connect with Vana"
+3. Approve in DataConnect desktop app
+4. Click "Fetch Data"
+
+## SDK Reference
+
+### Server imports (`@opendatalabs/connect/server`)
+
+```typescript
+import { createVanaConfig, connect, getData, signVanaManifest } from "@opendatalabs/connect/server";
+```
+
+- `createVanaConfig({ privateKey, scopes, appUrl })` — Creates config object
+- `connect(config)` — Creates session, returns `{ sessionId, connectUrl, expiresAt }`
+- `getData({ privateKey, grant, environment })` — Fetches data from Personal Server
+- `signVanaManifest({ privateKey, appUrl, ... })` — Signs manifest for identity verification
+
+### Client imports (`@opendatalabs/connect/react`)
+
+```typescript
+import { useVanaData } from "@opendatalabs/connect/react";
+```
+
+### Core imports (`@opendatalabs/connect/core`)
+
+```typescript
+import { ConnectError, isValidGrant } from "@opendatalabs/connect/core";
+import type { ConnectionStatus } from "@opendatalabs/connect/core";
+```
+
+## Tech Stack
+
+- **Framework**: Next.js 15 (App Router, React 19)
+- **Package manager**: pnpm (required, not npm)
+- **TypeScript**: ~5.7, strict mode, ES2022 target
+- **SDK**: `@opendatalabs/connect` ^0.8.1
+- **Crypto**: `viem` ^2.0.0 (Ethereum utilities)
+- **Path alias**: `@/*` → `./src/*`
+- **Dev server port**: 3001
+
+## What NOT to Do
+
+- Do NOT modify the API route handlers — they are thin SDK wrappers that work correctly as-is
+- Do NOT use npm — this project requires pnpm
+- Do NOT expose `VANA_PRIVATE_KEY` to the client — all signing happens server-side
+- Do NOT hardcode environment URLs — the SDK resolves environments automatically
+- Do NOT skip the manifest — DataConnect uses it to verify your app's identity
+- Do NOT add authentication to the connect/data API routes — the SDK handles auth via EIP-191/712
+- Do NOT call `initConnect()` without a `useRef` guard — React StrictMode will double-fire it

--- a/.claude/skills/vana-data-app/SKILL.md
+++ b/.claude/skills/vana-data-app/SKILL.md
@@ -140,7 +140,31 @@ The component must:
 3. Call `fetchData()` after approval to get user data
 4. Display the data in your app-specific way
 
-Data comes back keyed by scope: `{ "chatgpt.conversations": [...] }`
+**IMPORTANT — Actual response shape from `useVanaData().data`:**
+
+The `/api/data` route returns `{ data: ... }` and the hook exposes the full response body.
+Each scope value is NOT a bare array — it's an envelope with schema metadata and a nested `data` object:
+
+```
+{
+  "data": {                                    // from /api/data response
+    "chatgpt.conversations": {                 // scope key
+      "$schema": "https://...schema.json",
+      "version": "1.0",
+      "scope": "chatgpt.conversations",
+      "collectedAt": "2026-03-01T20:26:46Z",
+      "data": {                                // actual payload
+        "conversations": [...]
+      }
+    }
+  }
+}
+```
+
+To extract conversations: `data.data["chatgpt.conversations"].data.conversations`
+
+Timestamps like `create_time` may be **ISO 8601 strings** (e.g. `"2025-12-31T07:59:14.849720Z"`)
+rather than Unix timestamps. Always handle both formats when parsing dates.
 
 ### Step 6 — Test locally
 
@@ -189,6 +213,23 @@ import type { ConnectionStatus } from "@opendatalabs/connect/core";
 - **Crypto**: `viem` ^2.0.0 (Ethereum utilities)
 - **Path alias**: `@/*` → `./src/*`
 - **Dev server port**: 3001
+
+## Common Gotchas
+
+1. **`.env.local` overrides `.env`** — Next.js loads `.env.local` with higher priority. If
+   `.env.local` has placeholder values like `VANA_PRIVATE_KEY=0x...`, they override real values
+   in `.env`. Use only one env file, or ensure `.env.local` has the real key.
+
+2. **API errors are swallowed** — The catch blocks in API routes return generic messages.
+   Always include `console.error` logging to see the actual error in the terminal.
+
+3. **Data is deeply nested** — The response from `getData()` wraps each scope in an envelope
+   with `$schema`, `version`, `collectedAt`, and a nested `data` object containing the actual
+   payload. Don't assume `scope_key → array` — it's `scope_key → envelope → data → array`.
+
+4. **Timestamps are ISO strings** — Connector schemas return `create_time` as ISO 8601 strings
+   (e.g. `"2025-12-31T07:59:14Z"`), not Unix timestamps. Parse with `new Date(value)`, not
+   `parseFloat(value)`.
 
 ## What NOT to Do
 

--- a/.claude/skills/vana-data-app/templates/file-templates.md
+++ b/.claude/skills/vana-data-app/templates/file-templates.md
@@ -1,0 +1,306 @@
+# Vana Data App — File Templates
+
+Complete reference templates for all customizable files in a Vana data app.
+
+## src/config.ts
+
+```typescript
+import { createVanaConfig } from "@opendatalabs/connect/server";
+
+// Scopes define what user data your app requests.
+// Browse available scopes: https://github.com/vana-com/data-connectors/tree/main/schemas
+const SCOPES = ["chatgpt.conversations"];
+
+export const config = createVanaConfig({
+  privateKey: (process.env.VANA_PRIVATE_KEY ??
+    process.env.VANA_APP_PRIVATE_KEY) as `0x${string}`,
+  scopes: SCOPES,
+  appUrl: process.env.APP_URL ?? "",
+});
+```
+
+## src/app/api/connect/route.ts (DO NOT MODIFY)
+
+```typescript
+import { NextResponse } from "next/server";
+import { connect } from "@opendatalabs/connect/server";
+import { ConnectError } from "@opendatalabs/connect/core";
+import { config } from "@/config";
+
+export async function POST() {
+  try {
+    const result = await connect(config);
+    return NextResponse.json(result);
+  } catch (err) {
+    const message =
+      err instanceof ConnectError ? err.message : "Failed to create session";
+    const status = err instanceof ConnectError ? (err.statusCode ?? 500) : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+```
+
+## src/app/api/data/route.ts (DO NOT MODIFY)
+
+```typescript
+import { NextResponse } from "next/server";
+import { getData } from "@opendatalabs/connect/server";
+import { ConnectError, isValidGrant } from "@opendatalabs/connect/core";
+import { config } from "@/config";
+
+export async function POST(request: Request) {
+  const { grant } = await request.json();
+
+  if (!isValidGrant(grant)) {
+    return NextResponse.json(
+      { error: "Invalid grant payload" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const data = await getData({
+      privateKey: config.privateKey,
+      grant,
+      environment: config.environment,
+    });
+
+    return NextResponse.json({ data });
+  } catch (err) {
+    const message =
+      err instanceof ConnectError ? err.message : "Failed to fetch data";
+    const status = err instanceof ConnectError ? (err.statusCode ?? 500) : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+```
+
+## src/app/api/webhook/route.ts
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const payload = await request.json();
+
+  // TODO: Verify the webhook signature and process the grant notification.
+  console.log("[webhook] received:", JSON.stringify(payload));
+
+  return NextResponse.json({ received: true });
+}
+```
+
+## src/app/manifest.json/route.ts
+
+```typescript
+import { ConnectError } from "@opendatalabs/connect/core";
+import { signVanaManifest } from "@opendatalabs/connect/server";
+import { NextResponse } from "next/server";
+import { config } from "@/config";
+
+export async function GET() {
+  try {
+    const vanaBlock = await signVanaManifest({
+      privateKey: config.privateKey,
+      appUrl: config.appUrl,
+      privacyPolicyUrl: `${config.appUrl}/privacy`,
+      termsUrl: `${config.appUrl}/terms`,
+      supportUrl: `${config.appUrl}/support`,
+      webhookUrl: `${config.appUrl}/api/webhook`,
+    });
+
+    const manifest = {
+      name: "Your App Name",          // CUSTOMIZE
+      short_name: "YourApp",          // CUSTOMIZE
+      start_url: "/",
+      display: "standalone",
+      background_color: "#09090b",
+      theme_color: "#09090b",
+      icons: [
+        { src: "/icon.svg", sizes: "any", type: "image/svg+xml" },
+      ],
+      vana: vanaBlock,
+    };
+
+    return NextResponse.json(manifest, {
+      headers: { "Cache-Control": "public, max-age=86400" },
+    });
+  } catch (err) {
+    const message =
+      err instanceof ConnectError ? err.message : "Failed to sign manifest";
+    const status = err instanceof ConnectError ? (err.statusCode ?? 500) : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+```
+
+## src/components/ConnectFlow.tsx (skeleton for customization)
+
+```typescript
+"use client";
+
+import type { ConnectionStatus } from "@opendatalabs/connect/core";
+import { useVanaData } from "@opendatalabs/connect/react";
+import { useEffect, useRef } from "react";
+
+export default function ConnectFlow() {
+  const {
+    status,
+    grant,
+    data,
+    error,
+    connectUrl,
+    initConnect,
+    fetchData,
+    isLoading,
+  } = useVanaData();
+
+  // Guard against StrictMode double-fire
+  const initRef = useRef(false);
+  useEffect(() => {
+    if (!initRef.current) {
+      initRef.current = true;
+      void initConnect();
+    }
+  }, [initConnect]);
+
+  const sessionReady = !!connectUrl;
+
+  return (
+    <div>
+      {/* Phase 1: Connect */}
+      {status !== "approved" && (
+        <div>
+          {sessionReady ? (
+            <a href={connectUrl} target="_blank" rel="noopener noreferrer">
+              Connect with Vana
+            </a>
+          ) : (
+            <button onClick={() => void initConnect()} disabled={isLoading}>
+              {isLoading ? "Creating session..." : "Create session"}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Phase 2: Approved — fetch and display data */}
+      {status === "approved" && grant && (
+        <div>
+          <button onClick={fetchData} disabled={isLoading}>
+            {isLoading ? "Fetching..." : "Fetch Data"}
+          </button>
+
+          {data != null && (
+            <div>
+              {/* CUSTOMIZE: Replace with your data visualization */}
+              <pre>{JSON.stringify(data, null, 2)}</pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Errors */}
+      {error && <p style={{ color: "red" }}>{error}</p>}
+
+      {/* Reset */}
+      {status !== "idle" && status !== "connecting" && (
+        <button onClick={() => window.location.reload()}>Reset</button>
+      )}
+    </div>
+  );
+}
+```
+
+## src/app/page.tsx
+
+```typescript
+import ConnectFlow from "@/components/ConnectFlow";
+
+export default function Home() {
+  return (
+    <main style={{ maxWidth: 540, margin: "0 auto", padding: "64px 24px" }}>
+      <h1 style={{ fontSize: 22, fontWeight: 600, marginBottom: 8 }}>
+        Your App Name
+      </h1>
+      <p style={{ fontSize: 14, color: "#71717a", marginBottom: 40 }}>
+        Your app description.
+      </p>
+      <ConnectFlow />
+    </main>
+  );
+}
+```
+
+## src/app/layout.tsx
+
+```typescript
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Your App Name",
+  description: "Your app description",
+  manifest: "/manifest.json",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+## .env.local
+
+```
+# Builder key registered at https://account.vana.org/admin
+VANA_PRIVATE_KEY=0x...
+# Public URL of your deployed app
+APP_URL=http://localhost:3001
+```
+
+## package.json
+
+```json
+{
+  "name": "your-data-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev --port 3001",
+    "build": "pnpm --filter @opendatalabs/connect build && next build"
+  },
+  "dependencies": {
+    "@opendatalabs/connect": "^0.8.1",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "viem": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "typescript": "~5.7.0"
+  }
+}
+```
+
+## Known Scopes
+
+Common scope identifiers (check https://github.com/vana-com/data-connectors/tree/main/schemas for the full list):
+
+- `chatgpt.conversations` — ChatGPT conversation history
+- `instagram.posts` — Instagram posts and media
+- `instagram.profile` — Instagram profile data
+- `spotify.history` — Spotify listening history
+- `gmail.messages` — Gmail messages
+- `twitter.posts` — Twitter/X posts
+- `linkedin.profile` — LinkedIn profile data
+
+Scopes follow the pattern: `{source}.{data_type}` where the first segment is the platform name.

--- a/.claude/skills/vana-data-app/templates/file-templates.md
+++ b/.claude/skills/vana-data-app/templates/file-templates.md
@@ -32,6 +32,7 @@ export async function POST() {
     const result = await connect(config);
     return NextResponse.json(result);
   } catch (err) {
+    console.error("[POST /api/connect] session creation failed:", err);
     const message =
       err instanceof ConnectError ? err.message : "Failed to create session";
     const status = err instanceof ConnectError ? (err.statusCode ?? 500) : 500;
@@ -67,6 +68,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ data });
   } catch (err) {
+    console.error("[POST /api/data] data fetch failed:", err);
     const message =
       err instanceof ConnectError ? err.message : "Failed to fetch data";
     const status = err instanceof ConnectError ? (err.statusCode ?? 500) : 500;
@@ -290,6 +292,52 @@ APP_URL=http://localhost:3001
   }
 }
 ```
+
+## Actual API Response Shape
+
+The `/api/data` endpoint returns data in this structure. Each scope value is an **envelope**
+with schema metadata — the actual data is nested inside a `data` field:
+
+```json
+{
+  "data": {
+    "chatgpt.conversations": {
+      "$schema": "https://raw.githubusercontent.com/.../chatgpt.conversations.json",
+      "version": "1.0",
+      "scope": "chatgpt.conversations",
+      "collectedAt": "2026-03-01T20:26:46Z",
+      "data": {
+        "conversations": [
+          {
+            "id": "abc-123",
+            "title": "My conversation",
+            "create_time": "2025-12-31T07:59:14.849720Z",
+            "update_time": "2025-12-31T08:15:00Z",
+            "message_count": 12,
+            "messages": [
+              {
+                "id": "msg-1",
+                "role": "user",
+                "content": "Hello",
+                "content_type": "text",
+                "create_time": "2025-12-31T07:59:14Z",
+                "model": null
+              }
+            ]
+          }
+        ],
+        "total": 150
+      }
+    }
+  }
+}
+```
+
+**Key points:**
+- `useVanaData().data` contains the full response body including the outer `data` wrapper
+- Scope values are envelopes, NOT bare arrays — drill into `.data.conversations`
+- `create_time` is an **ISO 8601 string**, not a Unix timestamp
+- To extract: `data.data["chatgpt.conversations"].data.conversations`
 
 ## Known Scopes
 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ This Vana connect starter connects to users' personal data via the Vana Connect
 SDK. Help me customize it into [describe your app and data source — e.g. "a 
 Rick Rubin style ChatGPT conversation analyzer that pulls out poetic learnings"].
 
-  What to change:
-  1. SCOPES in src/config.ts — pick the right data types for my use case
-  2. App identity in src/app/manifest.json/route.ts — name, description,
-     privacy/terms URLs
-  3. The UI in src/components/ConnectFlow.tsx — redesign the data
-     display to do something useful with the fetched JSON
-  4. Homepage in src/app/page.tsx and styling in src/app/globals.css
+What to change:
+1. SCOPES in src/config.ts — pick the right data types for my use case
+2. App identity in src/app/manifest.json/route.ts — name, description,
+privacy/terms URLs
+3. The UI in src/components/ConnectFlow.tsx — redesign the data
+display to do something useful with the fetched JSON
+4. Homepage in src/app/page.tsx and styling in src/app/globals.css
 
-  Do NOT modify the API routes (src/app/api/connect, /data) —
-  those are thin wrappers around the SDK and work as-is.
-  Run `pnpm dev` to test.
+Do NOT modify the API routes (src/app/api/connect, /data) —
+those are thin wrappers around the SDK and work as-is.
+Run `pnpm dev` to test.
 ```
 
 

--- a/src/app/api/connect/route.ts
+++ b/src/app/api/connect/route.ts
@@ -11,6 +11,7 @@ export async function POST() {
     const result = await connect(config);
     return NextResponse.json(result);
   } catch (err) {
+    console.error("[POST /api/connect] session creation failed:", err);
     const message =
       err instanceof ConnectError ? err.message : "Failed to create session";
     const status = err instanceof ConnectError ? (err.statusCode ?? 500) : 500;

--- a/src/app/api/data/route.ts
+++ b/src/app/api/data/route.ts
@@ -24,6 +24,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ data });
   } catch (err) {
+    console.error("[POST /api/data] data fetch failed:", err);
     const message =
       err instanceof ConnectError ? err.message : "Failed to fetch data";
     const status = err instanceof ConnectError ? (err.statusCode ?? 500) : 500;


### PR DESCRIPTION
## Summary
- Adds a project-level Claude Code skill (`vana-data-app`) that teaches Claude how to create and customize Vana data apps using the Connect SDK
- Includes main instructions (SKILL.md) covering protocol flow, file roles, SDK reference, and anti-patterns
- Includes bundled file templates for all customizable files in the starter

## Test plan
- [x] Verify skill activates when asking Claude Code to "create a data app" or "customize the starter"
- [x] Verify file templates match current starter code patterns
- [x] Confirm skill does not trigger on unrelated prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)