### PR TITLE
Tighten readme

### DIFF
--- a/.claude/skills/vana-data-app/SKILL.md
+++ b/.claude/skills/vana-data-app/SKILL.md
@@ -32,7 +32,7 @@ the user's Personal Server using the grant.
 
 | File | What to change |
 |------|---------------|
-| `src/config.ts` | `SCOPES` array — pick data types for your use case |
+| `.env.local` | Set `VANA_SCOPES` (comma-separated scope keys) |
 | `src/app/manifest.json/route.ts` | App name, short_name, privacy/terms/support URLs |
 | `src/components/ConnectFlow.tsx` | UI — redesign data display, add visualizations, features |
 | `src/app/page.tsx` | Homepage — title, description, branding, layout |
@@ -70,27 +70,50 @@ cp .env.local.example .env.local
 ```
 
 Required environment variables:
-- `VANA_PRIVATE_KEY` — Builder private key (register at https://account.vana.org/admin)
-- `APP_URL` — `http://localhost:3001` for dev, HTTPS domain for production
+- `VANA_PRIVATE_KEY` — App private key (get it from https://account.vana.org/admin)
+- `APP_URL` — `http://localhost:3001` for dev, HTTPS domain for production (no trailing slash)
+- `VANA_SCOPES` — Comma-separated scope keys, e.g. `chatgpt.conversations,instagram.posts`
 
 ### Step 3 — Configure scopes
 
-Edit `src/config.ts`:
+Set scopes in `.env.local`:
+
+```bash
+VANA_SCOPES=chatgpt.conversations
+# or
+VANA_SCOPES=chatgpt.conversations,instagram.posts
+```
+
+`src/config.ts` reads `VANA_SCOPES` and validates required env vars (`VANA_PRIVATE_KEY`, `APP_URL`, `VANA_SCOPES`) at startup:
 
 ```typescript
 import { createVanaConfig } from "@opendatalabs/connect/server";
 
-const SCOPES = ["chatgpt.conversations"]; // Change to your data types
+const scopes = (process.env.VANA_SCOPES ?? "")
+  .split(",")
+  .map((scope) => scope.trim())
+  .filter(Boolean);
+const appUrl = (process.env.APP_URL ?? "").trim().replace(/\/+$/, "");
+const privateKey = (process.env.VANA_PRIVATE_KEY ?? "").trim();
+
+if (scopes.length === 0) {
+  throw new Error("Missing VANA_SCOPES");
+}
+
+if (!appUrl) {
+  throw new Error("Missing APP_URL");
+}
+
+if (!privateKey || !/^0x[0-9a-fA-F]{64}$/.test(privateKey)) {
+  throw new Error("Invalid VANA_PRIVATE_KEY");
+}
 
 export const config = createVanaConfig({
-  privateKey: (process.env.VANA_PRIVATE_KEY ??
-    process.env.VANA_APP_PRIVATE_KEY) as `0x${string}`,
-  scopes: SCOPES,
-  appUrl: process.env.APP_URL ?? "",
+  privateKey: privateKey as `0x${string}`,
+  scopes,
+  appUrl,
 });
 ```
-
-Multiple scopes are supported: `["chatgpt.conversations", "instagram.posts"]`
 
 ### Step 4 — Update app identity
 

--- a/.claude/skills/vana-data-app/SKILL.md
+++ b/.claude/skills/vana-data-app/SKILL.md
@@ -58,6 +58,7 @@ Ask the user (if not clear):
 3. What scopes are needed? (e.g. `chatgpt.conversations`, `instagram.posts`)
 
 Available scope schemas: https://github.com/vana-com/data-connectors/tree/main/schemas
+Scope key rule: use the schema filename without `.json` (for example `spotify.savedTracks.json` -> `spotify.savedTracks`).
 
 ### Step 2 — Scaffold or clone the starter
 

--- a/.claude/skills/vana-data-app/templates/file-templates.md
+++ b/.claude/skills/vana-data-app/templates/file-templates.md
@@ -375,7 +375,7 @@ Common scope identifiers (check https://github.com/vana-com/data-connectors/tree
 - `chatgpt.conversations` — ChatGPT conversation history
 - `instagram.posts` — Instagram posts and media
 - `instagram.profile` — Instagram profile data
-- `spotify.history` — Spotify listening history
+- `spotify.savedTracks` — Spotify saved tracks
 - `gmail.messages` — Gmail messages
 - `twitter.posts` — Twitter/X posts
 - `linkedin.profile` — LinkedIn profile data

--- a/.claude/skills/vana-data-app/templates/file-templates.md
+++ b/.claude/skills/vana-data-app/templates/file-templates.md
@@ -7,15 +7,41 @@ Complete reference templates for all customizable files in a Vana data app.
 ```typescript
 import { createVanaConfig } from "@opendatalabs/connect/server";
 
-// Scopes define what user data your app requests.
-// Browse available scopes: https://github.com/vana-com/data-connectors/tree/main/schemas
-const SCOPES = ["chatgpt.conversations"];
+const scopes = (process.env.VANA_SCOPES ?? "")
+  .split(",")
+  .map((scope) => scope.trim())
+  .filter(Boolean);
+const appUrl = (process.env.APP_URL ?? "").trim().replace(/\/+$/, "");
+const privateKey = (process.env.VANA_PRIVATE_KEY ?? "").trim();
+
+if (scopes.length === 0) {
+  throw new Error(
+    "Missing VANA_SCOPES. Set VANA_SCOPES in .env.local (comma-separated), e.g. VANA_SCOPES=chatgpt.conversations",
+  );
+}
+
+if (!appUrl) {
+  throw new Error(
+    "Missing APP_URL. Set APP_URL in .env.local, e.g. APP_URL=http://localhost:3001",
+  );
+}
+
+if (!privateKey) {
+  throw new Error(
+    "Missing VANA_PRIVATE_KEY. Set VANA_PRIVATE_KEY in .env.local.",
+  );
+}
+
+if (!/^0x[0-9a-fA-F]{64}$/.test(privateKey)) {
+  throw new Error(
+    "Invalid VANA_PRIVATE_KEY. Expected 0x followed by 64 hex characters.",
+  );
+}
 
 export const config = createVanaConfig({
-  privateKey: (process.env.VANA_PRIVATE_KEY ??
-    process.env.VANA_APP_PRIVATE_KEY) as `0x${string}`,
-  scopes: SCOPES,
-  appUrl: process.env.APP_URL ?? "",
+  privateKey: privateKey as `0x${string}`,
+  scopes,
+  appUrl,
 });
 ```
 
@@ -261,10 +287,13 @@ export default function RootLayout({
 ## .env.local
 
 ```
-# Builder key registered at https://account.vana.org/admin
+# App private key (get it from Vana Gateway: https://account.vana.org/admin)
 VANA_PRIVATE_KEY=0x...
-# Public URL of your deployed app
+# Public URL of your app (no trailing slash)
 APP_URL=http://localhost:3001
+# Required: comma-separated scopes
+# Scope list/schemas: https://github.com/vana-com/data-connectors/tree/main/schemas
+VANA_SCOPES=chatgpt.conversations
 ```
 
 ## package.json

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,8 +1,8 @@
-# You will need register this with Vana Data Gateway here to get started -
-# https://account.vana.org/admin
-# Builder key, must be registered on-chain
+# App private key (get it from Vana Gateway: https://account.vana.org/admin)
 VANA_PRIVATE_KEY=0x...
-# Public URL of your deployed app
+# Public URL of your app. Do NOT include a trailing slash.
 APP_URL=http://localhost:3001
-# Comma-separated scopes
+# Required: comma-separated scopes
+# Scope list/schemas: https://github.com/vana-com/data-connectors/tree/main/schemas
+# Example: chatgpt.conversations,instagram.posts
 VANA_SCOPES=chatgpt.conversations

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# llms
+.cursor

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ pnpm dev   # Opens on http://localhost:3001
 
 Use scope keys from the connector schema list: [https://github.com/vana-com/data-connectors/tree/main/schemas](https://github.com/vana-com/data-connectors/tree/main/schemas)
 
-- Each value must be a valid scope key (for example `chatgpt.conversations`, `instagram.posts`, `spotify.streaming_history`).
+- Each value must be a valid scope key (for example `chatgpt.conversations`, `instagram.posts`, `spotify.history`).
 - Multiple scopes are comma-separated.
 - Your app only receives data for scopes the user approves in DataConnect.
 

--- a/README.md
+++ b/README.md
@@ -4,52 +4,92 @@ Minimal Next.js app demonstrating the Vana Connect flow to port personal data in
 
 ## Prompting
 
-Paste this prompt into an AI to have it make you an app
+Paste this prompt into an AI to have it make you an app:
+
 ```
-This Vana connect starter connects to users' personal data via the Vana Connect 
-SDK. Help me customize it into [describe your app and data source — e.g. "a 
-Rick Rubin style ChatGPT conversation analyzer that pulls out poetic learnings"].
+Before writing code, fill these in:
+- Target app outcome: <exact user-facing feature>
+- Target scopes: <exact `VANA_SCOPES` values, comma-separated>
 
-What to change:
-1. SCOPES in src/config.ts — pick the right data types for my use case
-2. App identity in src/app/manifest.json/route.ts — name, description,
-privacy/terms URLs
-3. The UI in src/components/ConnectFlow.tsx — redesign the data
-display to do something useful with the fetched JSON
-4. Homepage in src/app/page.tsx and styling in src/app/globals.css
+This Vana Connect starter is a scaffold, not zero-config. It requires:
+- `VANA_PRIVATE_KEY`
+- `APP_URL`
+- `VANA_SCOPES`
+- a reachable Personal Server (DataConnect is the easiest local path)
 
-Do NOT modify the API routes (src/app/api/connect, /data) —
-those are thin wrappers around the SDK and work as-is.
-Run `pnpm dev` to test.
+Build this exactly:
+"Build a <specific user-facing app> powered by <specific Vana portable data scopes>."
+
+Allowed changes:
+1) `.env.local`
+   - Set `VANA_SCOPES` to only what the target app needs.
+2) `src/app/manifest.json/route.ts`
+   - Update `name`, `description`, `privacyUrl`, `termsUrl`.
+3) `src/components/ConnectFlow.tsx`
+   - Keep connect/grant behavior unchanged.
+   - Replace generic JSON display with useful app-specific output.
+4) `src/app/page.tsx` and `src/app/globals.css`
+   - Update homepage copy/layout/styles for the target app.
+
+Do NOT modify:
+- `src/app/api/connect/**`
+- `src/app/api/data/**`
+- signing/auth flow around the SDK wrappers
+
+Definition of done:
+- Connect flow still works (`idle -> waiting -> approved/error`).
+- Output is meaningful for the defined app outcome and uses the defined scopes.
+- `pnpm dev` starts successfully once required env/infra are provided.
+
+Return:
+- files changed
+- rationale per file
+- assumptions made
 ```
 
 
-## Prerequisites
+## Quick start
 
-- A builder address registered via the Vana Gateway. Set it up [here](https://account.vana.org/admin).
-- A running Personal Server with `VANA_MASTER_KEY_SIGNATURE` set. The easiest way to do this is through [DataConnect](https://account.vana.org/download-data-connect)
+Set these in `.env.local` before running:
 
-## Setup
+1. `VANA_PRIVATE_KEY` (your app private key). Get it from Vana Gateway: [https://account.vana.org/admin](https://account.vana.org/admin)
+2. `APP_URL` (use `http://localhost:3001` for local dev; no trailing slash)
+3. `VANA_SCOPES` (comma-separated scope keys, for example `chatgpt.conversations`)
+4. A reachable Personal Server (easiest path: [DataConnect](https://account.vana.org/download-data-connect))
 
 ```bash
 cp .env.local.example .env.local
-# Edit .env.local with your private key and APP_URL
+# .env.local
+# VANA_PRIVATE_KEY=0x... (64 hex chars after 0x)
+# APP_URL=http://localhost:3001
+# VANA_SCOPES=chatgpt.conversations,another.scope
 pnpm install
 pnpm dev   # Opens on http://localhost:3001
 ```
 
-## Environment Variables
+> Scopes are read from `VANA_SCOPES` only (comma-separated), e.g. `VANA_SCOPES=chatgpt.conversations,another.scope`.
 
-| Variable           | Required | Description                             |
-| ------------------ | -------- | --------------------------------------- |
-| `VANA_PRIVATE_KEY` | Yes      | Builder private key registered onchain (from prerequisites) |
-| `APP_URL`          | Yes      | Public URL of your deployed app. Use `http://localhost:3001` for local dev         |
+## Scopes
 
-> Scopes are configured in `src/config.ts`. Edit the `SCOPES` array to change which user data your app requests.
+`VANA_SCOPES` is the list of data permissions your app asks for.
+
+Use scope keys from the connector schema list: [https://github.com/vana-com/data-connectors/tree/main/schemas](https://github.com/vana-com/data-connectors/tree/main/schemas)
+
+- Each value must be a valid scope key (for example `chatgpt.conversations`, `instagram.posts`, `spotify.streaming_history`).
+- Multiple scopes are comma-separated.
+- Your app only receives data for scopes the user approves in DataConnect.
+
+Set one or more in `.env.local`:
+
+```bash
+VANA_SCOPES=chatgpt.conversations
+# or
+VANA_SCOPES=chatgpt.conversations,instagram.posts
+```
 
 ## Web App Manifest
 
-The app serves a W3C Web App Manifest at `/manifest.json` containing a signed `vana` block. The Desktop App uses this to verify the builder's identity. The manifest is generated dynamically using `signVanaManifest()` from the SDK, which signs the vana block fields with EIP-191 using your `VANA_PRIVATE_KEY`.
+The app serves a W3C Web App Manifest at `/manifest.json` containing a signed `vana` block. The Desktop App uses this to verify your app identity. The manifest is generated dynamically using `signVanaManifest()` from the SDK, which signs the vana block fields with EIP-191 using your `VANA_PRIVATE_KEY`.
 
 ## Webhook
 
@@ -61,13 +101,13 @@ Connect resolves your app icon from `APP_URL` in this order: `/icon.svg`, `/icon
 
 ## E2E Testing Workflow
 
-1. **Terminal 1** — Start your Personal Server (`pnpm dev`)
-2. **Terminal 2** — Start this app (`pnpm dev`)
-3. **Browser Tab 1** — Open `http://localhost:3001`, click "Connect with Vana"
-4. Click "Open in DataConnect" to launch the deep link, or if running a dev build of DataConnect, copy the deep link URL and paste it into the Personal Server Dev UI → Connect tab
-7. Click "Auto-Approve All" (or step through manually)
-8. Tab 1 updates from "Waiting..." to "Approved!" with grant details
+1. Download and open [DataConnect](https://account.vana.org/download-data-connect) (DataConnect manages your Personal Server, and the Personal Server stores your data and serves approved data requests to your app).
+2. In Terminal: start this app (`pnpm dev`).
+3. In a Browser Tab: open this app at `http://localhost:3001`, then click "Connect with Vana".
+4. Click "Open in DataConnect" to launch the deep link.
+5. In DataConnect, click "Auto-Approve All" (or approve step-by-step).
+6. Back in your Browser Tab, status updates from "Waiting…" to "Approved!" with grant details.
 
 ## Personal Server
 
-This app does not configure the Personal Server — it resolves the user's server URL at runtime via the Data Gateway. The Personal Server is a separate protocol participant (desktop-bundled, ODL Cloud, or self-hosted). See [Personal servers](https://docs.vana.org/protocol-reference/personal-servers) for details. 
+This app does not configure the Personal Server — it resolves the user's server URL at runtime via the Data Gateway. For most local setups, DataConnect runs the Personal Server for you. The Personal Server can also be desktop-bundled, ODL Cloud, or self-hosted. See [Personal servers](https://docs.vana.org/protocol-reference/personal-servers) for details.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ pnpm dev   # Opens on http://localhost:3001
 
 Use scope keys from the connector schema list: [https://github.com/vana-com/data-connectors/tree/main/schemas](https://github.com/vana-com/data-connectors/tree/main/schemas)
 
-- Each value must be a valid scope key (for example `chatgpt.conversations`, `instagram.posts`, `spotify.history`).
+- Scope key format is the schema filename without `.json` (for example `spotify.savedTracks.json` -> `spotify.savedTracks`).
+- Each value must be a valid scope key (for example `chatgpt.conversations`, `instagram.posts`, `spotify.savedTracks`).
 - Multiple scopes are comma-separated.
 - Your app only receives data for scopes the user approves in DataConnect.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,38 @@
 import { createVanaConfig } from "@opendatalabs/connect/server";
 
-// Scopes define what user data your app requests.
-const SCOPES = ["chatgpt.conversations"];
+const scopes = (process.env.VANA_SCOPES ?? "")
+  .split(",")
+  .map((scope) => scope.trim())
+  .filter(Boolean);
+const appUrl = (process.env.APP_URL ?? "").trim().replace(/\/+$/, "");
+const privateKey = (process.env.VANA_PRIVATE_KEY ?? "").trim();
+
+if (scopes.length === 0) {
+  throw new Error(
+    "Missing VANA_SCOPES. Set VANA_SCOPES in .env.local (comma-separated), e.g. VANA_SCOPES=chatgpt.conversations",
+  );
+}
+
+if (!appUrl) {
+  throw new Error(
+    "Missing APP_URL. Set APP_URL in .env.local, e.g. APP_URL=http://localhost:3001",
+  );
+}
+
+if (!privateKey) {
+  throw new Error(
+    "Missing VANA_PRIVATE_KEY. Set VANA_PRIVATE_KEY in .env.local.",
+  );
+}
+
+if (!/^0x[0-9a-fA-F]{64}$/.test(privateKey)) {
+  throw new Error(
+    "Invalid VANA_PRIVATE_KEY. Expected 0x followed by 64 hex characters.",
+  );
+}
 
 export const config = createVanaConfig({
-  privateKey: (process.env.VANA_PRIVATE_KEY ??
-    process.env.VANA_APP_PRIVATE_KEY) as `0x${string}`,
-  scopes: SCOPES,
-  appUrl: process.env.APP_URL ?? "",
+  privateKey: privateKey as `0x${string}`,
+  scopes,
+  appUrl,
 });


### PR DESCRIPTION
Things I did:

- `src/config.ts` now enforces env-only config (`VANA_PRIVATE_KEY`, `APP_URL`, `VANA_SCOPES`) with explicit validation and fail-fast errors. This prevents silent misconfig and catches bad setup before runtime connect calls.

- `.env.local.example` now clearly documents required vars + scope format (moving Scopes into `.env` means devs now only manage `.env` and the manifest. Config is runtime checking only). This reduces onboarding/setup mistakes and keeps local `.env` shape consistent.

- `README.md` was rewritten around env-first setup, scope guidance, and a stricter AI handoff prompt; plus latest fix correcting Spotify scope example. Docs now match actual runtime behavior and prevent invalid-scope failures.

- `.claude/skills/vana-data-app/*` updated to align with env-first scopes and current starter behavior.  