### PR TITLE
fix(docs): correct invalid scope references

### DIFF
--- a/.claude/skills/vana-data-app/SKILL.md
+++ b/.claude/skills/vana-data-app/SKILL.md
@@ -11,7 +11,7 @@ description: >
 # Vana Data App Builder
 
 Build Next.js applications that access users' portable personal data (ChatGPT conversations,
-Instagram posts, Spotify history, etc.) via the Vana Connect protocol. Apps use the
+Instagram posts, Spotify saved tracks, etc.) via the Vana Connect protocol. Apps use the
 `@opendatalabs/connect` SDK for session creation, grant polling, and data retrieval.
 
 ## Core Architecture
@@ -54,7 +54,7 @@ the user's Personal Server using the grant.
 
 Ask the user (if not clear):
 1. What does the app do with the data? (analyze, visualize, export, transform)
-2. Which data sources? (chatgpt, instagram, spotify, gmail, etc.)
+2. Which data sources? (chatgpt, instagram, spotify, linkedin, etc.)
 3. What scopes are needed? (e.g. `chatgpt.conversations`, `instagram.posts`)
 
 Available scope schemas: https://github.com/vana-com/data-connectors/tree/main/schemas

--- a/.claude/skills/vana-data-app/templates/file-templates.md
+++ b/.claude/skills/vana-data-app/templates/file-templates.md
@@ -376,8 +376,7 @@ Common scope identifiers (check https://github.com/vana-com/data-connectors/tree
 - `instagram.posts` — Instagram posts and media
 - `instagram.profile` — Instagram profile data
 - `spotify.savedTracks` — Spotify saved tracks
-- `gmail.messages` — Gmail messages
-- `twitter.posts` — Twitter/X posts
 - `linkedin.profile` — LinkedIn profile data
+- `github.profile` — GitHub profile data
 
 Scopes follow the pattern: `{source}.{data_type}` where the first segment is the platform name.


### PR DESCRIPTION
## Summary

- Removed `gmail.messages` from Known Scopes list -- no Gmail connector exists in the data-connectors registry
- Removed `twitter.posts` from Known Scopes list -- Twitter connector is marked `comingSoon`, not available
- Changed "Spotify history" to "Spotify saved tracks" in SKILL.md description to match the actual scope `spotify.savedTracks`
- Replaced `gmail` with `linkedin` in the data-source prompt (SKILL.md line 57) since Gmail is not a valid source
- Added `github.profile` as a replacement example scope

## Files changed

- `.claude/skills/vana-data-app/SKILL.md` -- fixed prose reference and data-source list
- `.claude/skills/vana-data-app/templates/file-templates.md` -- fixed Known Scopes list

## Test plan

- [ ] Verify scope list in `file-templates.md` matches [data-connectors/schemas](https://github.com/vana-com/data-connectors/tree/main/schemas)
- [ ] Confirm no remaining references to `gmail.messages`, `twitter.posts`, or `spotify.history` in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)